### PR TITLE
Bump OZ version, remove unneeded import

### DIFF
--- a/contracts/Import.sol
+++ b/contracts/Import.sol
@@ -1,6 +1,0 @@
-//SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
-
-// These imports are here to force Hardhat to compile contracts we depend on but don't need anywhere else.
-// https://github.com/wighawag/template-ethereum-contracts/blob/examples/openzeppelin-proxies/src/Proxy/Import.sol
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "run:coverage": "set TS_NODE_TRANSPILE_ONLY=1 && npx hardhat coverage"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.7.1",
-    "@openzeppelin/contracts-upgradeable": "4.7.1"
+    "@openzeppelin/contracts": "4.8.0",
+    "@openzeppelin/contracts-upgradeable": "4.8.0"
   },
   "devDependencies": {
     "@fireblocks/hardhat-fireblocks": "^0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,15 +986,15 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz#f63fc384255d6ac139e0a2561aa207fd7c14183c"
-  integrity sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg==
+"@openzeppelin/contracts-upgradeable@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.0.tgz#26688982f46969018e3ed3199e72a07c8d114275"
+  integrity sha512-5GeFgqMiDlqGT8EdORadp1ntGF0qzWZLmEY7Wbp/yVhN7/B3NNzCxujuI77ktlyG81N3CUZP8cZe3ZAQ/cW10w==
 
-"@openzeppelin/contracts@4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.1.tgz#33d0a857b76b18d313e6bb6ed28cdaf367e90cfe"
-  integrity sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw==
+"@openzeppelin/contracts@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
+  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
 "@openzeppelin/hardhat-upgrades@^1.21.0":
   version "1.21.0"


### PR DESCRIPTION
- Bump OZ to 4.8
- Remove unneeded Import.sol . That was needed when we use wighawag's deploy-contract project but we don't use that anymore.