### PR TITLE
Prevent minting zero, restructure mint tests

### DIFF
--- a/contracts/EUROe.sol
+++ b/contracts/EUROe.sol
@@ -154,6 +154,7 @@ contract EUROe is
         external
         onlyRole(MINTER_ROLE)
     {
+        require(amount > 0, "Mint amount not greater than 0");
         _mint(account, amount);
     }
 

--- a/contracts/EUROe.sol
+++ b/contracts/EUROe.sol
@@ -154,7 +154,6 @@ contract EUROe is
         external
         onlyRole(MINTER_ROLE)
     {
-        require(amount > 0, "Mint amount not greater than 0");
         _mint(account, amount);
     }
 

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -872,10 +872,8 @@ describe("Token", () => {
           .withArgs(ethers.constants.AddressZero, user1.address, 2);
       });
 
-      it("can't mint zero", async () => {
-        await expect(
-          erc20.connect(minter).mint(user1.address, 0)
-        ).to.revertedWith("Mint amount not greater than 0");
+      it("can mint zero", async () => {
+        erc20.connect(minter).mint(user1.address, 0);
       });
 
       it("minting to blocked address fails", async () => {

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -858,114 +858,140 @@ describe("Token", () => {
   });
 
   describe("Minting", () => {
-    it("single mint", async () => {
-      await expect(() =>
-        erc20.connect(minter).mint(user1.address, 2)
-      ).to.changeTokenBalance(erc20, user1, 2);
-      await expect(await erc20.totalSupply()).to.equal(mintAmount + 2);
+    describe("Single minting", () => {
+      it("works", async () => {
+        await expect(() =>
+          erc20.connect(minter).mint(user1.address, 2)
+        ).to.changeTokenBalance(erc20, user1, 2);
+        await expect(await erc20.totalSupply()).to.equal(mintAmount + 2);
+      });
+
+      it("emits transfer events", async () => {
+        await expect(erc20.connect(minter).mint(user1.address, 2))
+          .to.emit(erc20, "Transfer")
+          .withArgs(ethers.constants.AddressZero, user1.address, 2);
+      });
+
+      it("can't mint zero", async () => {
+        await expect(
+          erc20.connect(minter).mint(user1.address, 0)
+        ).to.revertedWith("Mint amount not greater than 0");
+      });
+
+      it("minting to blocked address fails", async () => {
+        await erc20
+          .connect(blocklister)
+          .grantRole(getRoleBytes(BLOCKED_ROLE), user1.address);
+
+        await expect(
+          erc20.connect(minter).mint(user1.address, 2)
+        ).to.revertedWith("Blocked user");
+      });
     });
 
-    it("single mint with permit", async () => {
-      await expect(() =>
-        singleMint(erc20, minter, user1.address, 2)
-      ).to.changeTokenBalance(erc20, user1, 2);
-      await expect(await erc20.totalSupply()).to.equal(mintAmount + 2);
-    });
+    describe("Multiple minting", () => {
+      it("works for single", async () => {
+        await expect(() =>
+          singleMint(erc20, minter, user1.address, 2)
+        ).to.changeTokenBalance(erc20, user1, 2);
+        await expect(await erc20.totalSupply()).to.equal(mintAmount + 2);
+      });
 
-    it("multiple mint", async () => {
-      const targets = [user1.address, user2.address, admin.address];
-      const amounts = [1, 2, 3];
-      await expect(() =>
-        erc20
-          .connect(minter)
-          .mintSet(targets, amounts, 1, getMintChecksum(targets, amounts, 1))
-      ).to.changeTokenBalances(erc20, [user1, user2, admin], [1, 2, 3]);
-      await expect(await erc20.totalSupply()).to.equal(mintAmount + 6);
-    });
+      it("works for multiple", async () => {
+        const targets = [user1.address, user2.address, admin.address];
+        const amounts = [1, 2, 3];
+        await expect(() =>
+          erc20
+            .connect(minter)
+            .mintSet(targets, amounts, 1, getMintChecksum(targets, amounts, 1))
+        ).to.changeTokenBalances(erc20, [user1, user2, admin], [1, 2, 3]);
+        await expect(await erc20.totalSupply()).to.equal(mintAmount + 6);
+      });
 
-    it("can mint multiple times to the same target", async () => {
-      const targets = [user1.address, user1.address, admin.address];
-      const amounts = [1, 2, 4];
-      await expect(() =>
-        erc20
-          .connect(minter)
-          .mintSet(targets, amounts, 1, getMintChecksum(targets, amounts, 1))
-      ).to.changeTokenBalances(erc20, [user1, admin], [3, 4]);
-      await expect(await erc20.totalSupply()).to.equal(mintAmount + 7);
-    });
+      it("can mint multiple times to the same target", async () => {
+        const targets = [user1.address, user1.address, admin.address];
+        const amounts = [1, 2, 4];
+        await expect(() =>
+          erc20
+            .connect(minter)
+            .mintSet(targets, amounts, 1, getMintChecksum(targets, amounts, 1))
+        ).to.changeTokenBalances(erc20, [user1, admin], [3, 4]);
+        await expect(await erc20.totalSupply()).to.equal(mintAmount + 7);
+      });
 
-    it("emits main event", async () => {
-      await expect(
-        erc20
-          .connect(minter)
-          .mintSet(
-            [user1.address],
-            [7],
-            6,
-            getMintChecksum([user1.address], [7], 6)
-          )
-      )
-        .to.emit(erc20, "MintingSetCompleted")
-        .withArgs(6);
-    });
+      it("emits main event", async () => {
+        await expect(
+          erc20
+            .connect(minter)
+            .mintSet(
+              [user1.address],
+              [7],
+              6,
+              getMintChecksum([user1.address], [7], 6)
+            )
+        )
+          .to.emit(erc20, "MintingSetCompleted")
+          .withArgs(6);
+      });
 
-    it("emits transfer events", async () => {
-      const user1Amount = 7;
-      const user2Amount = 8;
-      const id = 6;
-      await expect(
-        erc20
-          .connect(minter)
-          .mintSet(
-            [user1.address, user2.address],
-            [user1Amount, user2Amount],
-            id,
-            getMintChecksum(
+      it("emits transfer events", async () => {
+        const user1Amount = 7;
+        const user2Amount = 8;
+        const id = 6;
+        await expect(
+          erc20
+            .connect(minter)
+            .mintSet(
               [user1.address, user2.address],
               [user1Amount, user2Amount],
-              id
+              id,
+              getMintChecksum(
+                [user1.address, user2.address],
+                [user1Amount, user2Amount],
+                id
+              )
             )
-          )
-      )
-        .to.emit(erc20, "Transfer")
-        .withArgs(ethers.constants.AddressZero, user1.address, user1Amount)
-        .to.emit(erc20, "Transfer")
-        .withArgs(ethers.constants.AddressZero, user2.address, user2Amount);
-    });
+        )
+          .to.emit(erc20, "Transfer")
+          .withArgs(ethers.constants.AddressZero, user1.address, user1Amount)
+          .to.emit(erc20, "Transfer")
+          .withArgs(ethers.constants.AddressZero, user2.address, user2Amount);
+      });
 
-    it("can't mint zero", async () => {
-      await expect(
-        erc20
-          .connect(minter)
-          .mintSet(
-            [minter.address],
-            [0],
-            1,
-            getMintChecksum([minter.address], [0], 1)
-          )
-      ).to.revertedWith("Mint amount not greater than 0");
-    });
+      it("can't mint zero", async () => {
+        await expect(
+          erc20
+            .connect(minter)
+            .mintSet(
+              [minter.address],
+              [0],
+              1,
+              getMintChecksum([minter.address], [0], 1)
+            )
+        ).to.revertedWith("Mint amount not greater than 0");
+      });
 
-    it("minting empty list fails", async () => {
-      await expect(
-        erc20.connect(minter).mintSet([], [], 1, getMintChecksum([], [], 1))
-      ).to.revertedWith("Nothing to mint");
-    });
+      it("minting empty list fails", async () => {
+        await expect(
+          erc20.connect(minter).mintSet([], [], 1, getMintChecksum([], [], 1))
+        ).to.revertedWith("Nothing to mint");
+      });
 
-    it("minting mismatch fails", async () => {
-      await expect(
-        erc20.connect(minter).mintSet([], [1], 1, getMintChecksum([], [1], 1))
-      ).to.revertedWith("Unmatching mint lengths");
-    });
+      it("minting mismatch fails", async () => {
+        await expect(
+          erc20.connect(minter).mintSet([], [1], 1, getMintChecksum([], [1], 1))
+        ).to.revertedWith("Unmatching mint lengths");
+      });
 
-    it("minting to blocked address fails", async () => {
-      await erc20
-        .connect(blocklister)
-        .grantRole(getRoleBytes(BLOCKED_ROLE), user1.address);
+      it("minting to blocked address fails", async () => {
+        await erc20
+          .connect(blocklister)
+          .grantRole(getRoleBytes(BLOCKED_ROLE), user1.address);
 
-      await expect(singleMint(erc20, minter, user1.address, 2)).to.revertedWith(
-        "Blocked user"
-      );
+        await expect(
+          singleMint(erc20, minter, user1.address, 2)
+        ).to.revertedWith("Blocked user");
+      });
     });
 
     describe("batch minting checksum", () => {


### PR DESCRIPTION
- Add check to prevent trying to mint zero amount, for regular minting
- Restructure minting related tests: make basic minting into its own 'describe' section and move multiple mint to their own section. Add a few missing basic minting tests.