### PR TITLE
Burn permit spending requires the right role

### DIFF
--- a/contracts/EUROe.sol
+++ b/contracts/EUROe.sol
@@ -141,7 +141,7 @@ contract EUROe is
         bytes32 r,
         bytes32 s
     ) public onlyRole(BURNER_ROLE) {
-        require(hasRole(BURNER_ROLE, spender));
+        require(msg.sender == spender, "Invalid spender");
         super.permit(owner, spender, value, deadline, v, r, s);
         super.burnFrom(owner, value);
     }

--- a/contracts/EUROe.sol
+++ b/contracts/EUROe.sol
@@ -141,6 +141,7 @@ contract EUROe is
         bytes32 r,
         bytes32 s
     ) public onlyRole(BURNER_ROLE) {
+        require(hasRole(BURNER_ROLE, spender));
         super.permit(owner, spender, value, deadline, v, r, s);
         super.burnFrom(owner, value);
     }

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -924,6 +924,48 @@ describe("Token", () => {
       expect(allowance).to.be.equal(value);
     });
 
+    it("using the same permit twice fails", async () => {
+      const value = 3;
+      const deadline =
+        (await ethers.provider.getBlock("latest")).timestamp + 5000;
+
+      const permit = await signERC2612Permit(
+        userWithTokens,
+        erc20.address,
+        userWithTokens.address,
+        burner.address,
+        value,
+        deadline
+      );
+
+      await erc20
+        .connect(userWithTokens)
+        .permit(
+          userWithTokens.address,
+          burner.address,
+          value,
+          deadline,
+          permit.v,
+          permit.r,
+          permit.s
+        );
+
+      // reuse
+      await expect(
+        erc20
+          .connect(userWithTokens)
+          .permit(
+            userWithTokens.address,
+            burner.address,
+            value,
+            deadline,
+            permit.v,
+            permit.r,
+            permit.s
+          )
+      ).to.be.revertedWith("ERC20Permit: invalid signature");
+    });
+
     it("creating expired permit fails", async () => {
       const value = 3;
       const deadline =

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -860,14 +860,33 @@ describe("Token", () => {
         );
       });
 
-      it("fails if spender isn't a burner", async () => {
+      it("fails if spender isn't the sender", async () => {
         const value = 2;
         const deadline =
           (await ethers.provider.getBlock("latest")).timestamp + 5000;
 
+        const result = await signERC2612Permit(
+          userWithTokens,
+          erc20.address,
+          userWithTokens.address,
+          user1.address,
+          value,
+          deadline
+        );
+
         await expect(
-          burnWithPermit(erc20, userWithTokens, user1, value, deadline)
-        ).to.revertedWith(getRoleError(user1.address, BURNER_ROLE));
+          erc20
+            .connect(burner)
+            .burnFromWithPermit(
+              userWithTokens.address,
+              user1.address,
+              value,
+              deadline,
+              result.v,
+              result.r,
+              result.s
+            )
+        ).to.revertedWith("Invalid spender");
       });
     });
   });

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -827,6 +827,14 @@ describe("Token", () => {
         await expect(burn).to.revertedWith("ERC20: insufficient allowance");
       });
 
+      it("burning without enough balance fails", async () => {
+        //await erc20.connect(userWithTokens).transfer(burner.address, 2);
+        const burn = erc20.connect(burner).burn(2);
+        await expect(burn).to.revertedWith(
+          "ERC20: burn amount exceeds balance"
+        );
+      });
+
       it("burning from blocked address fails", async () => {
         await erc20.connect(userWithTokens).approve(burner.address, 5);
         await erc20
@@ -858,6 +866,16 @@ describe("Token", () => {
           userWithTokens,
           -2
         );
+      });
+
+      it("fails if not enough balance", async () => {
+        const value = 2;
+        const deadline =
+          (await ethers.provider.getBlock("latest")).timestamp + 5000;
+
+        await expect(
+          burnWithPermit(erc20, user1, burner, value, deadline)
+        ).to.be.revertedWith("ERC20: burn amount exceeds balance");
       });
 
       it("fails if spender isn't the sender", async () => {


### PR DESCRIPTION
- Add restrictions that "burnFromWithPermit" spender has to be the sender
- Add unit test for it
- Restructure burn tests so regular burning and permit burning are separated
- Add checks for missing balance in regular burning and permit burning
- Add test for reusing the same permit (should fail)