### PR TITLE
Fix blocklister typo in test

### DIFF
--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -403,7 +403,7 @@ describe("Token", () => {
         await expect(
           erc20
             .connect(blocklister)
-            .renounceRole(getRoleBytes(BLOCKED_ROLE), blocklister.address)
+            .renounceRole(getRoleBytes(BLOCKLISTER_ROLE), blocklister.address)
         ).to.be.revertedWith("Not supported");
       });
     });


### PR DESCRIPTION
Fix a typo in tests which tested renouncing own role for the wrong role.