### PR TITLE
Add test for paused minting

### DIFF
--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -764,7 +764,14 @@ describe("Token", () => {
       ).to.revertedWith("Pausable: paused");
     });
 
-    it("prevents minting", async () => {
+    it("prevents single minting", async () => {
+      await erc20.connect(pauser).pause();
+      await expect(
+        erc20.connect(minter).mint(user1.address, 2)
+      ).to.revertedWith("Pausable: paused");
+    });
+
+    it("prevents batch minting", async () => {
       await erc20.connect(pauser).pause();
       await expect(singleMint(erc20, minter, user1.address, 1)).to.revertedWith(
         "Pausable: paused"


### PR DESCRIPTION
Add unit test which checks that one can't mint when the contract has been paused

This will probably conflict with https://github.com/membranefi/euroe-stablecoin/pull/33